### PR TITLE
Use RIPE Atlas Cousteau for fetching probes meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This tool will eat up all your RIPE ATLAS credits if you are not careful.
     * pip install pyresample
     * pip install requests
     * pip install ripe.atlas.sagan[fast]
-    * pip install https://github.com/RIPE-NCC/ripe-atlas-cousteau/zipball/master
+    * pip install https://github.com/RIPE-NCC/ripe-atlas-cousteau/zipball/latest
 
 # Naming
 Maera was the daugther of Atlas.


### PR DESCRIPTION
Hi,

I came across your repo recently. Nice visualizations :)
I noticed that there was a FIXME part in the code, so I went ahead and tried to fix it. The latest version of cousteau supports the traversing of the Probes API ,so it's easier (and cleaner) now to get a list of probes. I also, changed the pip install link for Cousteau, I think is better to use always latest instead of master. This will make sure you install a stable package.

Cheers,
Andreas
